### PR TITLE
Fix wasm bug with cgal eigen3 support not found

### DIFF
--- a/cmake/importDependenciesHelpers.cmake
+++ b/cmake/importDependenciesHelpers.cmake
@@ -331,6 +331,7 @@ macro(importDependency_EIGEN3 _useSystem _target_dependencies _target_definition
       GIT_TAG 5.0.1 #1dd76c8d07637cc878632ea76a129c6ac53d07034f4d
       #GIT_SHALLOW ON
     )
+    set(FEELPP_EIGEN3_VERSION "5.0.1" PARENT_SCOPE)
     set(EIGEN_BUILD_CMAKE_PACKAGE ON)
     set(EIGEN_BUILD_PKGCONFIG ON)
     FetchContent_MakeAvailable(eigen3)
@@ -372,7 +373,9 @@ macro(importDependency_CGAL _useSystem _target_dependencies _target_definitions 
     # workaround with CGAL cmake : feelpp has EIGEN3 but not cmake var EIGEN3_FOUND
     if (FEELPP_HAS_EIGEN3 AND NOT EIGEN3_FOUND )
       set( EIGEN3_FOUND 1)
-      set( Eigen3_VERSION 3.3.8)
+    endif()
+    if (FEELPP_EIGEN3_VERSION AND NOT Eigen3_VERSION)
+      set( Eigen3_VERSION FEELPP_EIGEN3_VERSION)
     endif()
     include(CGAL_Eigen3_support)
     if ( EMSCRIPTEN )

--- a/cmake/importDependenciesHelpers.cmake
+++ b/cmake/importDependenciesHelpers.cmake
@@ -328,7 +328,7 @@ macro(importDependency_EIGEN3 _useSystem _target_dependencies _target_definition
   else()
     FetchContent_Declare( eigen3 GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
       #GIT_TAG 3.4.0
-      GIT_TAG 02bcf9b5918d46016bc88e5e9abebb6caa5a80b7
+      GIT_TAG 5.0.1 #1dd76c8d07637cc878632ea76a129c6ac53d07034f4d
       #GIT_SHALLOW ON
     )
     set(EIGEN_BUILD_CMAKE_PACKAGE ON)

--- a/cmake/importDependenciesHelpers.cmake
+++ b/cmake/importDependenciesHelpers.cmake
@@ -372,8 +372,9 @@ macro(importDependency_CGAL _useSystem _target_dependencies _target_definitions 
     # workaround with CGAL cmake : feelpp has EIGEN3 but not cmake var EIGEN3_FOUND
     if (FEELPP_HAS_EIGEN3 AND NOT EIGEN3_FOUND )
       set( EIGEN3_FOUND 1)
+      set( Eigen3_VERSION 3.3.8)
     endif()
-    #include(CGAL_Eigen3_support)
+    include(CGAL_Eigen3_support)
     if ( EMSCRIPTEN )
       target_compile_definitions( CGAL INTERFACE CGAL_ALWAYS_ROUND_TO_NEAREST)
     endif()

--- a/cmake/importDependenciesHelpers.cmake
+++ b/cmake/importDependenciesHelpers.cmake
@@ -373,7 +373,7 @@ macro(importDependency_CGAL _useSystem _target_dependencies _target_definitions 
     if (FEELPP_HAS_EIGEN3 AND NOT EIGEN3_FOUND )
       set( EIGEN3_FOUND 1)
     endif()
-    include(CGAL_Eigen3_support)
+    #include(CGAL_Eigen3_support)
     if ( EMSCRIPTEN )
       target_compile_definitions( CGAL INTERFACE CGAL_ALWAYS_ROUND_TO_NEAREST)
     endif()

--- a/cmake/importDependenciesHelpers.cmake
+++ b/cmake/importDependenciesHelpers.cmake
@@ -375,7 +375,7 @@ macro(importDependency_CGAL _useSystem _target_dependencies _target_definitions 
       set( EIGEN3_FOUND 1)
     endif()
     if (FEELPP_EIGEN3_VERSION AND NOT Eigen3_VERSION)
-      set( Eigen3_VERSION FEELPP_EIGEN3_VERSION)
+      set( Eigen3_VERSION ${FEELPP_EIGEN3_VERSION} )
     endif()
     include(CGAL_Eigen3_support)
     if ( EMSCRIPTEN )


### PR DESCRIPTION
- Updated Eigen to 5.0.1 
- Hotfix: Manually set Eigen3_VERSION to 3.3.8 so that CGAL compiles. 
- [ ] TODO: Investigate why eigen3_version is not set. 

c.f. changes for CGAL 6.1.1 in https://github.com/CGAL/cgal/blob/9e36c6744beac0d387d33d29f9736a38dc4102e7/Installation/cmake/modules/CGAL_Eigen3_support.cmake

```c++
if((EIGEN3_FOUND OR Eigen3_FOUND) AND NOT TARGET CGAL::Eigen3_support)
  if ("${Eigen3_VERSION}" VERSION_LESS "3.3.7")
    set (EIGEN3_FOUND 0)
    find_package(Eigen3 3.3.7 QUIET) # (3.3.7 or greater)
  endif()
endif()
``` 