### PR TITLE
Bug/patch cgal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build wheel
         run: |
           source .venv/bin/activate
-          pipx run build
+          uv build
           uv pip install dist/*.whl
 
       - name: Upload Artifact

--- a/cmake/cgal.patch
+++ b/cmake/cgal.patch
@@ -1,0 +1,13 @@
+diff --git a/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h b/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
+index 785ea3cd5..5214ac4c4 100644
+--- a/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
++++ b/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
+@@ -1271,7 +1271,7 @@ protected:
+     const auto face_id = static_cast<std::size_t>(cell->ccdt_3_data().face_constraint_index(facet_index));
+     this->face_constraint_misses_subfaces_set(face_id);
+     auto fh_2 = cell->ccdt_3_data().face_2(this->face_cdt_2[face_id], facet_index);
+-    fh_2->info().facet_3d = {};
++    fh_2->info().facet_3d = decltype(fh_2->info().facet_3d){};
+     fh_2->info().missing_subface = true;
+     this->set_facet_constrained({cell, facet_index}, -1, {});
+   }

--- a/cmake/importDependenciesHelpers.cmake
+++ b/cmake/importDependenciesHelpers.cmake
@@ -353,6 +353,7 @@ macro(importDependency_CGAL _useSystem _target_dependencies _target_definitions 
   else()
     FetchContent_Declare( cgal GIT_REPOSITORY https://github.com/CGAL/cgal.git
       GIT_TAG v6.1.1 # v6.0.1 #  v5.6
+      PATCH_COMMAND git apply "${FEELPP_CORE_CMAKE_DIR}/cgal.patch" UPDATE_DISCONNECTED 1
       #GIT_TAG 5ffa817b6211a4bcec05faf85726bc4845682d50
       GIT_SHALLOW ON
     )


### PR DESCRIPTION
Added a CGAL patch to fix compilation for the wasm64-linux preset concerning an Emscripten rant on ambiguous initialisation of a variable.  