### PR TITLE
Add tui components

### DIFF
--- a/examples/feelcore-tui.cpp
+++ b/examples/feelcore-tui.cpp
@@ -1,13 +1,14 @@
 //!
 
 #include <fstream>
+
 #include <ftxui/component/component.hpp>
 #include <ftxui/dom/elements.hpp>
 #include <ftxui/screen/screen.hpp>
 
 #include <feel/feelcore/tui/taskmanager.hpp>
 #include <feel/feelcore/tui/components.hpp>
-
+#include <feel/feelcore/timekeeper.hpp>
 
 #include <feel/feelcore/feelcore.hpp>
 
@@ -43,10 +44,10 @@ int main( int argc, char** argv )
 
     // ========== READOUT SLIDERS ========= //
     int intValue = 50;
-    Component intSlider = ReadoutSlider<int>( &intValue, 0, 100, 1, "Int Readout Slider", 0 ); 
+    Component intSlider = ReadoutSlider<int>( &intValue, 0, 100, 1, "Int Readout Slider", 0 );
 
     float doubleValue = 0.5;
-    Component doubleSlider = ReadoutSlider<float>( &doubleValue, 0, 1, 0.1, "Double Readout Slider", 2 ); 
+    Component doubleSlider = ReadoutSlider<float>( &doubleValue, 0, 1, 0.1, "Double Readout Slider", 2 );
 
     Component readoutSliders = Container::Vertical( { intSlider, doubleSlider } );
     //=======================================//
@@ -54,12 +55,12 @@ int main( int argc, char** argv )
 
     //============= SPINBOX ==============//
     int spinboxValue = 0;
-    Component spinbox = SpinBox( spinboxValue, "SpinBox " ); 
+    Component spinbox = SpinBox( spinboxValue, "SpinBox " );
     //=======================================//
 
     //============= FILE INPUT ==============//
     std::string filepath;
-    Component fileInput = FileInput( &filepath, " Enter your filepath..." ); 
+    Component fileInput = FileInput( &filepath, " Enter your filepath..." );
     //=======================================//
 
 
@@ -109,6 +110,43 @@ int main( int argc, char** argv )
 
     //=======================================//
 
+
+    //================== LOGVIEWER ==================
+    auto logViewer = TuiLogViewer( 100 );
+    spdlog::set_level( spdlog::level::debug );
+    spdlog::info( "This is an info message" );
+    spdlog::warn( "This is a warning message" );
+    spdlog::error( "This is an error message" );
+    spdlog::debug( "This is a debug message" );
+
+    //===============================================//
+
+    //============ TIMEKEEPER VIEWER ==================
+    Feel::Core::Timekeeper::instance()->setEnabled( true );
+    auto timekeeperViewer = TuiTimekeeperViewer( 3 );
+    Component startTimersButton = WorkerButton( screen, []() -> std::string {
+        {
+            Feel::Core::Timer t1( "Task 1" );
+            std::this_thread::sleep_for( 500ms );
+            {
+                Feel::Core::Timer t2( "Task 1.1" );
+                std::this_thread::sleep_for( 200ms );
+            }
+            {
+                Feel::Core::Timer t3( "Task 1.2" );
+                std::this_thread::sleep_for( 300ms );
+            }
+        }
+        {
+            Feel::Core::Timer t4( "Task 2" );
+            std::this_thread::sleep_for( 400ms );
+        }
+        return "Timers completed";
+    }, "Start Timers" );
+    Component timekeeperContainer = Container::Horizontal( { timekeeperViewer, startTimersButton} );
+
+    //===============================================//
+
     //================== TABS ==================
     int selectedTab = 0;
     std::vector<std::string> inputTabs = {
@@ -118,20 +156,24 @@ int main( int argc, char** argv )
         "SpinBox",
         "FileInput",
         "WorkerButton",
-        "FileLoader"
+        "FileLoader",
+        "LogViewer",
+        "TimekeeperViewer"
     };
 
     Component tabsMenu = Menu( &inputTabs, &selectedTab );
 
-    Component tabsContainer = Container::Tab( { 
+    Component tabsContainer = Container::Tab( {
         multiOptionSelector,
         radioSelector,
         readoutSliders,
         spinbox,
         fileInput,
         workerButtons,
-        fileLoader
-    }, &selectedTab ); 
+        fileLoader,
+        logViewer,
+        timekeeperContainer
+    }, &selectedTab );
 
     //=======================================//
 
@@ -139,7 +181,7 @@ int main( int argc, char** argv )
 
     auto layout = Renderer( masterContainer, [&tabsMenu, &tabsContainer]() {
         return hbox( {
-            tabsMenu->Render(), 
+            tabsMenu->Render(),
             separator(),
             tabsContainer->Render() | flex
         } );

--- a/examples/feelcore-tui.cpp
+++ b/examples/feelcore-tui.cpp
@@ -147,6 +147,21 @@ int main( int argc, char** argv )
 
     //===============================================//
 
+    //================== HEATMAP ==================
+    auto heatmap = Heatmap( 40, 20 );
+    heatmap->setData( []( double x, double y ) -> std::optional<double> {
+        if ( x < -100 || x > 100 || y < -100 || y > 100 )
+            return std::nullopt;
+
+        double value = std::sin( x * 10 ) * std::cos( y * 10 );
+        return value;
+    }, -1.0, 1.0 );
+    Component resetViewportButton = WorkerButton( screen, [heatmap]() -> std::string {
+        heatmap->resetView();
+        return "Viewport reset";
+    }, "Reset Viewport" );
+    Component heatmapContainer = Container::Horizontal( { heatmap, resetViewportButton } );
+
     //================== TABS ==================
     int selectedTab = 0;
     std::vector<std::string> inputTabs = {
@@ -158,7 +173,8 @@ int main( int argc, char** argv )
         "WorkerButton",
         "FileLoader",
         "LogViewer",
-        "TimekeeperViewer"
+        "TimekeeperViewer",
+        "Heatmap"
     };
 
     Component tabsMenu = Menu( &inputTabs, &selectedTab );
@@ -172,7 +188,8 @@ int main( int argc, char** argv )
         workerButtons,
         fileLoader,
         logViewer,
-        timekeeperContainer
+        timekeeperContainer,
+        heatmapContainer
     }, &selectedTab );
 
     //=======================================//

--- a/src/feel/feelcore/CMakeLists.txt
+++ b/src/feel/feelcore/CMakeLists.txt
@@ -6,5 +6,6 @@ set(FEELPP_CORE_LIB_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/table.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/tabulateinformations.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/threadpool.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/timekeeper.cpp
   ${FEELPP_CORE_LIB_SRCS_TUI}
   PARENT_SCOPE )

--- a/src/feel/feelcore/timekeeper.cpp
+++ b/src/feel/feelcore/timekeeper.cpp
@@ -1,0 +1,145 @@
+//!
+
+#include <fstream>
+
+#include <feel/feelcore/timekeeper.hpp>
+
+
+namespace Feel::Core
+{
+
+std::unique_ptr<Timekeeper> Timekeeper::S_instance = nullptr;
+thread_local std::vector<std::string> Timekeeper::M_context;
+std::once_flag Timekeeper::S_onceFlag;
+
+Timekeeper*
+Timekeeper::instance()
+{
+    std::call_once( S_onceFlag, []() {
+        S_instance = std::unique_ptr<Timekeeper>( new Timekeeper() );
+    } );
+    return S_instance.get();
+}
+
+void
+Timekeeper::recordTime( double time )
+{
+    std::unique_lock<std::shared_mutex> lock( M_mutex );
+    bool isRoot = true;
+    nl::json * current = &M_times;
+
+    for ( std::string const& key : M_context )
+    {
+        if ( key.empty() )
+            continue;
+
+        if ( isRoot )
+        {
+            if ( !current->contains( key ) )
+                (*current)[key] = nl::json::object();
+            current = &(*current)[key];
+            isRoot = false;
+        }
+        else
+        {
+            if ( !current->contains( "subsections" ) )
+                (*current)["subsections"] = nl::json::object();
+
+            nl::json & subsections = (*current)["subsections"];
+            if ( !subsections.contains( key ) )
+                subsections[key] = nl::json::object();
+
+            current = &subsections[key];
+        }
+    }
+
+    if ( !current->contains( "times" ) )
+        (*current)["times"] = nl::json::object();
+
+    nl::json & times = (*current)["times"];
+
+    if ( times.contains( "elapsed" ) ||  times.contains( "elapsed_sum" ))
+    {
+        double elapsed =  times.contains( "elapsed_sum" ) ? times.at( "elapsed_sum" ) : times.at( "elapsed" );
+        times["elapsed_sum"] = elapsed + time;
+        times["count"] = times.value( "count", 1 ) + 1;
+        times["min"] = std::min( times.value( "min", elapsed ),time );
+        times["max"] = std::max( times.value( "max", elapsed ),time);
+        times.erase( "elapsed" );
+    }
+    else
+        times["elapsed"] = time;
+}
+
+
+void
+Timekeeper::popContext( )
+{
+    if ( M_context.empty() )
+    {
+        log::warn("Timekeeper popContext called without matching pushContext.");
+        return;
+    }
+    M_context.pop_back();
+}
+
+void
+Timekeeper::save( fs::path const& filename ) const
+{
+    if ( ! Timekeeper::instance()->isEnabled() ) return;
+
+    std::ofstream file( filename );
+    if ( !file.is_open() )
+        throw std::runtime_error( "Could not open file to save timekeeper data: " + filename.string() );
+
+    //TODO: Evaluate memory overhead and copy cost (snapshot) VS locking the dump.
+    nl::json timesSnapshot;
+    {
+        // Protects against concurrent recordTime() calls mutating M_times
+        // Shared lock sufficient because save() is readonly
+        std::shared_lock<std::shared_mutex> lock( M_mutex );
+        timesSnapshot = M_times;
+    }
+    file << timesSnapshot.dump( 4 );
+}
+
+
+
+void
+Timer::tic( std::string const& name, std::string const& msg, int verboseLvl )
+{
+    if ( ! Timekeeper::instance()->isEnabled() ) return;
+    if ( verboseLvl > 0 && !msg.empty() )
+        log::info( "Starting: {}", msg );
+
+    Timekeeper::instance()->pushContext( name );
+    M_timeStack.push( std::make_tuple( Clock::now(), msg, verboseLvl ) );
+}
+
+double
+Timer::toc()
+{
+    if ( ! Timekeeper::instance()->isEnabled() ) return 0.0;
+
+    if ( M_timeStack.empty() )
+    {
+        log::warn( "Timer toc called without matching tic." );
+        return 0.0;
+    }
+
+    auto & [ start, msg, verboseLvl ] = M_timeStack.top();
+
+    double elapsed = std::chrono::duration<double>(  Clock::now() - start ).count();
+
+    if ( verboseLvl > 0 && !msg.empty() )
+        log::info( "{} done in {} s", msg, elapsed );
+
+    Timekeeper::instance()->recordTime( elapsed );
+    Timekeeper::instance()->popContext( );
+
+    M_timeStack.pop();
+    return elapsed;
+}
+
+
+} // namespace Feel::Core

--- a/src/feel/feelcore/timekeeper.hpp
+++ b/src/feel/feelcore/timekeeper.hpp
@@ -1,0 +1,115 @@
+
+//!
+
+#pragma once
+
+#include <chrono>
+#include <stack>
+#include <shared_mutex>
+
+#include <feel/feelcore/environment.hpp>
+
+namespace Feel::Core
+{
+
+//! Singleton class to keep track of elapsed times in different code sections
+class Timekeeper
+{
+public:
+
+    //! Get the singleton instance
+    static Timekeeper* instance();
+
+    //! Returns true if timekeeping is enabled
+    bool isEnabled() const noexcept { return M_enabled; };
+
+    //! Enable or disable timekeeping
+    void setEnabled( bool enabled ) { M_enabled = enabled; };
+
+    //! Get a snapshot of the recorded times as a JSON object
+    nl::json const&
+    getTimesSnapshot() const noexcept
+    {
+        std::shared_lock<std::shared_mutex> lock( M_mutex );
+        return M_times;
+    };
+
+    //! Save the recorded times to a JSON file
+    void save( fs::path const& filename ) const;
+
+
+    //! Clear the recorder times
+    void clear()
+    {
+        std::unique_lock<std::shared_mutex> lock( M_mutex );
+        M_times.clear();
+    };
+
+    //! Get the thread local context
+    std::vector<std::string> const& getContext() const noexcept { return M_context; }
+
+    //! Get the thread local context
+    void setContext( std::vector<std::string> const& ctx ) { M_context = ctx; }
+
+private:
+    Timekeeper() = default;
+    Timekeeper( Timekeeper const& ) = delete;
+    Timekeeper& operator=( Timekeeper const& ) = delete;
+
+    //! Record elapsed time in seconds for the current context
+    void recordTime( double time );
+
+    //! Push a new context level
+    void pushContext( std::string const& name ) { M_context.push_back( name ); };
+
+    //! Pop the last context level
+    void popContext();
+
+private:
+    static std::unique_ptr<Timekeeper> S_instance;
+    nl::json M_times = nl::json::object();
+    static thread_local std::vector<std::string> M_context;
+    mutable std::shared_mutex M_mutex;
+    static std::once_flag S_onceFlag;
+
+    static inline std::atomic<bool> M_enabled{ false };
+
+    friend class Timer;
+};
+
+//! Timer utility class to measure elapsed time of code hierarchical sections
+class Timer
+{
+    using Clock = std::chrono::high_resolution_clock;
+    using TimePoint = std::chrono::time_point<Clock>;
+public:
+
+    Timer() = default;
+
+    //! RAII timer, starts timing upon construction and stops upon destruction ( or until toc )
+    template<typename... Ts>
+    Timer( Ts && ... v )
+    {
+        this->tic( std::forward<Ts>( v )... );
+    };
+
+    //! Tocs if not already stopped
+    ~Timer()
+    {
+        while ( !M_timeStack.empty() )
+            this->toc();
+    };
+
+    //! Start timing a new section
+    void tic(std::string const& name = "", std::string const& msg = "", int verboseLvl = 1);
+
+    //! Stop timing the last started section and return elapsed time in seconds
+    double toc();
+
+private:
+    std::stack<std::tuple<TimePoint, std::string, int>> M_timeStack; // start time, message, verbose level
+};
+
+
+
+}

--- a/src/feel/feelcore/tui/CMakeLists.txt
+++ b/src/feel/feelcore/tui/CMakeLists.txt
@@ -2,4 +2,5 @@ set(FEELPP_CORE_LIB_SRCS_TUI
   ${CMAKE_CURRENT_SOURCE_DIR}/taskmanager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/components.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fileinput.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/decorators.cpp
   PARENT_SCOPE )

--- a/src/feel/feelcore/tui/CMakeLists.txt
+++ b/src/feel/feelcore/tui/CMakeLists.txt
@@ -5,4 +5,5 @@ set(FEELPP_CORE_LIB_SRCS_TUI
   ${CMAKE_CURRENT_SOURCE_DIR}/decorators.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/logviewer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/timekeeperviewer.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/viewport.cpp
   PARENT_SCOPE )

--- a/src/feel/feelcore/tui/CMakeLists.txt
+++ b/src/feel/feelcore/tui/CMakeLists.txt
@@ -3,4 +3,6 @@ set(FEELPP_CORE_LIB_SRCS_TUI
   ${CMAKE_CURRENT_SOURCE_DIR}/components.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/fileinput.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/decorators.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/logviewer.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/timekeeperviewer.cpp
   PARENT_SCOPE )

--- a/src/feel/feelcore/tui/CMakeLists.txt
+++ b/src/feel/feelcore/tui/CMakeLists.txt
@@ -6,4 +6,5 @@ set(FEELPP_CORE_LIB_SRCS_TUI
   ${CMAKE_CURRENT_SOURCE_DIR}/logviewer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/timekeeperviewer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/viewport.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/heatmap.cpp
   PARENT_SCOPE )

--- a/src/feel/feelcore/tui/components.cpp
+++ b/src/feel/feelcore/tui/components.cpp
@@ -188,7 +188,19 @@ ftxui::Component FileLoader( ftxui::ScreenInteractive & screen, ftxui::StringRef
 }
 
 
+std::shared_ptr<TuiLogViewerComponent>
+TuiLogViewer( std::size_t maxEntries )
+{
+    return std::make_shared<TuiLogViewerComponent>( maxEntries );
+}
 
+
+
+std::shared_ptr<TuiTimekeeperViewerComponent>
+TuiTimekeeperViewer( int maxDepth )
+{
+    return std::make_shared<TuiTimekeeperViewerComponent>( maxDepth );
+}
 
 
 } //namespace Feel::Core::tui

--- a/src/feel/feelcore/tui/components.cpp
+++ b/src/feel/feelcore/tui/components.cpp
@@ -202,5 +202,10 @@ TuiTimekeeperViewer( int maxDepth )
     return std::make_shared<TuiTimekeeperViewerComponent>( maxDepth );
 }
 
+std::shared_ptr<HeatmapComponent>
+Heatmap(int width, int height, bool allowZoom, bool allowPan )
+{
+    return std::make_shared<HeatmapComponent>(width, height, allowZoom, allowPan);
+}
 
 } //namespace Feel::Core::tui

--- a/src/feel/feelcore/tui/components.hpp
+++ b/src/feel/feelcore/tui/components.hpp
@@ -6,6 +6,8 @@
 #include <ftxui/component/screen_interactive.hpp>
 
 #include <feel/feelcore/feelcore.hpp>
+#include <feel/feelcore/tui/logviewer.hpp>
+#include <feel/feelcore/tui/timekeeperviewer.hpp>
 
 namespace Feel::Core::tui
 {
@@ -16,7 +18,7 @@ ftxui::Component FEELPP_CORE_EXPORT MultiOptionSelector( std::vector<std::pair<s
 //! Styled and labeled window with vertical radio buttons
 ftxui::Component FEELPP_CORE_EXPORT RadioSelector( std::vector<std::string> const* entries, int * selected, std::string const& label = "" );
 
-//! Styled and labeled slider that displays the current value 
+//! Styled and labeled slider that displays the current value
 template <typename T>
 ftxui::Component ReadoutSlider( ftxui::Ref<T> value, T min = 0., T max = 1., T step = 0.1,
                                 std::string const& title = "", int displayPrecision = 1 );
@@ -42,5 +44,15 @@ public:
 //! Container containing a file input with load + unload buttons and feedback
 ftxui::Component FEELPP_CORE_EXPORT FileLoader( ftxui::ScreenInteractive & screen, ftxui::StringRef content, IFileLoaderHandler & loadHandler,
                                                 ftxui::StringRef placeholder = "", ftxui::InputOption inputOptions = {} );
+
+
+//! Component that displays the log messages in a scrollable list with filters for log levels.
+//! Convenience function to comply to FTXUI pattern.
+std::shared_ptr<TuiLogViewerComponent> TuiLogViewer( std::size_t maxEntries = 100 );
+
+
+//! Component that displays the recorded times from the Timekeeper in a scrollable and collapsible list.
+//! Convenience function to comply to FTXUI pattern.
+std::shared_ptr<TuiTimekeeperViewerComponent> TuiTimekeeperViewer( int maxDepth = 3 );
 
 } //namespace Feel::Core::tui

--- a/src/feel/feelcore/tui/components.hpp
+++ b/src/feel/feelcore/tui/components.hpp
@@ -8,6 +8,7 @@
 #include <feel/feelcore/feelcore.hpp>
 #include <feel/feelcore/tui/logviewer.hpp>
 #include <feel/feelcore/tui/timekeeperviewer.hpp>
+#include <feel/feelcore/tui/heatmap.hpp>
 
 namespace Feel::Core::tui
 {
@@ -54,5 +55,9 @@ std::shared_ptr<TuiLogViewerComponent> TuiLogViewer( std::size_t maxEntries = 10
 //! Component that displays the recorded times from the Timekeeper in a scrollable and collapsible list.
 //! Convenience function to comply to FTXUI pattern.
 std::shared_ptr<TuiTimekeeperViewerComponent> TuiTimekeeperViewer( int maxDepth = 3 );
+
+
+//! Component that displays a heatmap of values in a scrollable and zoomable viewport.
+std::shared_ptr<HeatmapComponent> Heatmap(int width, int height, bool allowZoom = true, bool allowPan = true);
 
 } //namespace Feel::Core::tui

--- a/src/feel/feelcore/tui/decorators.cpp
+++ b/src/feel/feelcore/tui/decorators.cpp
@@ -1,0 +1,81 @@
+//!
+
+
+#include <ftxui/component/event.hpp>
+
+#include <feel/feelcore/tui/decorators.hpp>
+
+
+namespace Feel::Core::tui
+{
+
+ftxui::Element
+ScrollableList::OnRender()
+{
+    std::vector<ftxui::Element> listElements = buildElements();
+
+    int maxScroll = std::max( 0, ( int )listElements.size() - 1 );
+    M_scrollState = std::clamp( M_scrollState, 0, maxScroll );
+
+    if ( !listElements.empty() )
+        listElements[ M_scrollState ] |= ftxui::focus;
+
+    if ( M_autoScroll && M_scrollState >= (int)listElements.size() - 2 )
+        M_scrollState = (int)listElements.size();
+
+    ftxui::Elements content;
+
+    if ( auto header = buildHeader() )
+    {
+        content.push_back( *header );
+        content.push_back( ftxui::separatorLight() );
+    }
+
+    content.push_back( ftxui::vbox( listElements ) | ftxui::vscroll_indicator
+                                                   | ftxui::yframe
+                                                   | ftxui::reflect( M_box )
+                                                   | ftxui::flex
+    );
+
+    if ( auto footer = buildFooter() )
+    {
+        content.push_back( ftxui::separatorLight() );
+        content.push_back( *footer );
+    }
+
+    return ftxui::window(
+        ftxui::text( M_title ) | ftxui::bold,
+        ftxui::vbox( content )
+    );
+
+}
+
+
+bool
+ScrollableList::OnEvent( ftxui::Event event )
+{
+    if ( ComponentBase::OnEvent( event ) )
+        return true;
+
+    if ( !event.is_mouse() )
+        return false;
+
+    if ( !M_box.Contain(event.mouse().x, event.mouse().y) )
+        return false;
+
+    if ( event.mouse().button == ftxui::Mouse::WheelDown )
+    {
+        M_scrollState += 1;
+        return true;
+    }
+    if ( event.mouse().button == ftxui::Mouse::WheelUp )
+    {
+        M_scrollState -= 1;
+        return true;
+    }
+
+    return false;
+}
+
+
+}

--- a/src/feel/feelcore/tui/decorators.hpp
+++ b/src/feel/feelcore/tui/decorators.hpp
@@ -1,0 +1,217 @@
+
+//!
+
+#pragma once
+
+#include <ftxui/component/component_base.hpp>
+#include <ftxui/component/component.hpp>
+
+#include <feel/feelcore/feelcore.hpp>
+
+namespace Feel::Core::tui
+{
+
+namespace detail
+{
+    inline std::string
+    toLower( std::string const& text )
+    {
+        std::string textLower = text;
+        std::transform( textLower.begin(), textLower.end(), textLower.begin(),
+                        []( unsigned char c ){ return std::tolower( c ); } );
+        return textLower;
+    }
+};
+
+
+//! Scrollable list base class with optional header and footer.
+//! To be used as a base class and implement the buildElements() method to provide the list elements.
+//! Will automatically handle scrolling and focus management of the list elements.
+class ScrollableList
+    : public ftxui::ComponentBase
+{
+    using Element = ftxui::Element;
+public:
+
+    //! @param title The title of the list.
+    //! @param autoScroll If true, the list will automatically scroll to the bottom when new items are added (e.g for logging).
+    explicit ScrollableList( std::string const& title = "", bool autoScroll = false )
+        : M_title( title ), M_autoScroll( autoScroll )
+    {}
+
+    //! Build the list elements to be displayed in the scrollable list.
+    virtual std::vector<Element> buildElements() = 0;
+
+    //! Build the optional sticky header element to be displayed above the list.
+    virtual std::optional<Element> buildHeader() { return std::nullopt; }
+
+    //! Build the optional sticky footer element to be displayed below the list.
+    virtual std::optional<Element> buildFooter() { return std::nullopt; }
+
+    //! Assembles the list elements, header and footer into a single element to be rendered.
+    Element OnRender() override;
+
+    //! Handles scrolling and focus management of the list elements.
+    bool OnEvent( ftxui::Event event ) override;
+
+private:
+    std::string M_title;
+    int M_scrollState = 0;
+    bool M_autoScroll = false;
+    ftxui::Box M_box;
+};
+
+
+
+//! Scrollable list with search bar and optional bulk action buttons.
+//! To be used as a base class and implement the onBulkAction() method to handle bulk
+//! And optionally implement the buildElements() method to provide the list elements.
+//! Will automatically handle filtering of the list elements based on the search query and scrolling and focus management of the list elements.
+template <typename T>
+class SearchableList
+    : public ScrollableList
+{
+protected:
+    struct Item
+    {
+        std::string searchTest;
+        ftxui::Component component;
+        T data;
+    };
+
+public:
+    //! @param title The title of the list.
+    //! @param autoScroll If true, the list will automatically scroll to the bottom when new items are added.
+    //! @param enableBulkActions If true, bulk action buttons will be displayed below the search bar.
+    explicit SearchableList( std::string const& title = "",
+                                      bool autoScroll = false,
+                                      bool enableBulkActions = false )
+        : ScrollableList( title, autoScroll ), M_enableBulkActions( enableBulkActions )
+    {
+        M_searchInput = ftxui::Input( &M_searchQuery, "Search...", { .on_change = [this](){ applyFilter(); } } );
+
+        if ( M_enableBulkActions )
+        {
+            initBulkActionButtons();
+            ScrollableList::Add( ftxui::Container::Vertical( {
+                M_searchInput,
+                ftxui::Container::Horizontal( { M_selectAllBtn, M_deselectAllBtn } ),
+                M_listContainer
+            } ) );
+        }
+        else
+            ScrollableList::Add( ftxui::Container::Vertical( { M_searchInput, M_listContainer } ) );
+    }
+
+    //! Add a data item to the list.
+    //! @param searchTest The text to be used for filtering the item.
+    //! @param component The component to be displayed for the item (e.g. ftxui::Checkbox)
+    //! @param data The data associated with the item.
+    void addItem( std::string const& searchTest, ftxui::Component component, T const& data = T() )
+    {
+        M_allItems.push_back( { searchTest, component, data } );
+        applyFilter();
+    }
+
+    //! Clear all items from the list.
+    void clearItems()
+    {
+        M_allItems.clear();
+        applyFilter();
+    }
+
+protected:
+
+    //! Called when the bulk action buttons are pressed.
+    //! @param active If true, the "Select All" button was pressed, otherwise the "Deselect All" button was pressed.
+    virtual void onBulkAction( bool active ) {}
+
+    //! Get the filtered items after applying the search query.
+    std::vector<Item*> const& filteredItems() const { return M_filteredItems; }
+
+    //! Get the current search query.
+    std::string const& searchQuery() const { return M_searchQuery; }
+
+    //! Build the header element with the search bar and optional bulk action buttons.
+    std::optional<ftxui::Element> buildHeader() override
+    {
+         auto searchbar = ftxui::hbox({ ftxui::text( "🔍 " ), M_searchInput->Render() | ftxui::flex });
+         if ( M_enableBulkActions )
+         {
+            auto bulkActions = ftxui::hbox({
+                 ftxui::filler(), ftxui::text("Select: ") | ftxui::dim,
+                 M_selectAllBtn->Render(), ftxui::text("  "), M_deselectAllBtn->Render()
+             });
+
+             return ftxui::vbox( { searchbar, bulkActions } );
+         }
+         else
+             return searchbar;
+    }
+
+    //! Build the list elements to be displayed in the scrollable list.
+    virtual std::vector<ftxui::Element> buildElements() override
+    {
+        std::vector<ftxui::Element> elements;
+        for ( auto & item : M_filteredItems )
+            elements.push_back( item->component->Render() );
+        return elements;
+    }
+
+private:
+
+    //! Initialize the bulk action buttons with custom styling and event handling.
+    void initBulkActionButtons()
+    {
+        auto styleButton = []( ftxui::EntryState const& s, ftxui::Color const& color )
+        {
+            auto element = ftxui::text( s.label ) | ftxui::color( color );
+            if ( s.focused )
+                element |= ftxui::inverted;
+            return element;
+        };
+
+        auto selectOpt = ftxui::ButtonOption::Ascii();
+        selectOpt.transform = [&styleButton]( ftxui::EntryState const& s ) { return styleButton( s, ftxui::Color::GreenLight ); };
+        M_selectAllBtn = ftxui::Button( "✓ All", [this](){ onBulkAction(true); }, selectOpt );
+
+        auto deselectOpt = ftxui::ButtonOption::Ascii();
+        deselectOpt.transform = [&styleButton]( ftxui::EntryState const& s ) { return styleButton( s, ftxui::Color::RedLight ); };
+        M_deselectAllBtn = ftxui::Button("✗ None", [this](){ onBulkAction(false); }, deselectOpt );
+    }
+
+    //! Apply the search query to filter the list items and update the displayed list.
+    void applyFilter()
+    {
+        M_listContainer->DetachAllChildren();
+        M_filteredItems.clear();
+
+        std::string query = detail::toLower( M_searchQuery );
+
+        for ( auto & item : M_allItems )
+        {
+            if ( query.empty() || detail::toLower( item.searchTest ).find( query ) != std::string::npos )
+            {
+                M_filteredItems.push_back( &item );
+                M_listContainer->Add( item.component );
+            }
+        }
+    }
+
+private:
+    std::string M_searchQuery;
+    ftxui::Component M_searchInput;
+    ftxui::Component M_listContainer = ftxui::Container::Vertical( {} );
+
+    ftxui::Component M_selectAllBtn;
+    ftxui::Component M_deselectAllBtn;
+    bool M_enableBulkActions = true;
+
+    std::vector<Item> M_allItems;
+    std::vector<Item*> M_filteredItems;
+};
+
+
+
+}
+

--- a/src/feel/feelcore/tui/heatmap.cpp
+++ b/src/feel/feelcore/tui/heatmap.cpp
@@ -1,0 +1,74 @@
+//!
+
+#include <feel/feelcore/tui/heatmap.hpp>
+
+namespace Feel::Core::tui
+{
+
+void
+HeatmapNode::Render( ftxui::Screen & screen )
+{
+    double valueRange = std::max( M_maxValue - M_minValue, 0.001 );
+
+    for ( int y = box_.y_min; y <= box_.y_max; ++y )
+    {
+        int baseYTop = ( y - box_.y_min ) * 2;
+        int baseYBot = baseYTop + 1;
+
+        if ( baseYTop >= M_height ) continue;
+
+        for ( int x = box_.x_min; x <= box_.x_max; ++x )
+        {
+            int pixelX = x - box_.x_min;
+
+            if ( pixelX >= M_width ) continue;
+
+            auto valTop = M_sampler( pixelX, baseYTop );
+            auto valBot = M_sampler( pixelX, baseYBot );
+
+            ftxui::Color colorTop = ftxui::Color::Black;
+            if ( valTop )
+                colorTop = getHeatmapColor( ( *valTop - M_minValue) / valueRange );
+
+            ftxui::Color colorBot = ftxui::Color::Black;
+            if ( valBot )
+                colorBot = getHeatmapColor( ( *valBot - M_minValue ) / valueRange );
+
+            auto & pixel = screen.PixelAt(x, y);
+            pixel.character = "▀";
+            pixel.foreground_color = colorTop;
+            pixel.background_color = colorBot;
+        }
+    }
+}
+
+ftxui::Color
+HeatmapNode::getHeatmapColor( double normalizedValue )
+{
+    double v = std::clamp( normalizedValue, 0.0, 1.0 );
+    return ftxui::Color::HSV( static_cast<uint8_t>( (1. - v) * 170. ), 255, 255 );
+}
+
+
+
+ftxui::Element
+HeatmapComponent::OnRender()
+{
+    if ( !M_sampler )
+        return ftxui::text("No heatmap data") | ftxui::center | ftxui::border;
+
+    auto pixelToWorldSampler = [ this ]( int pixelX, int pixelY ) -> std::optional<double>
+    {
+        double worldX = ( pixelX - M_pan.x() ) / M_zoom;
+        double worldY = ( pixelY - M_pan.y() ) / M_zoom;
+
+        return M_sampler( worldX, worldY );
+    };
+
+    auto rasterNode = std::make_shared<HeatmapNode>( M_width, M_height, M_minValue, M_maxValue, pixelToWorldSampler );
+
+    return ftxui::Element(rasterNode) | ftxui::reflect(M_box) |  ftxui::center;
+}
+
+
+}

--- a/src/feel/feelcore/tui/heatmap.hpp
+++ b/src/feel/feelcore/tui/heatmap.hpp
@@ -1,0 +1,69 @@
+//!
+
+#pragma once
+
+#include <ftxui/component/component_base.hpp>
+
+#include <feel/feelcore/feelcore.hpp>
+#include <feel/feelcore/tui/viewport.hpp>
+
+
+namespace Feel::Core::tui
+{
+
+class HeatmapNode : public ftxui::Node
+{
+    using PixelSampler = std::function<std::optional<double>(int, int)>;
+
+public:
+    HeatmapNode( int width, int height, double minValue, double maxValue, PixelSampler sampler )
+        : M_width(width), M_height(height), M_minValue(minValue), M_maxValue(maxValue), M_sampler(sampler) {}
+
+    void ComputeRequirement() override
+    {
+        requirement_.min_x = M_width;
+        requirement_.min_y = M_height / 2;
+    }
+
+    void Render( ftxui::Screen & screen ) override;
+
+private:
+
+    ftxui::Color getHeatmapColor(double normalizedValue);
+
+private:
+    int M_width, M_height;
+    double M_minValue, M_maxValue;
+    PixelSampler M_sampler;
+};
+
+
+
+class HeatmapComponent
+    : public Viewport
+{
+public:
+    HeatmapComponent( int width, int height, bool allowZoom = true, bool allowPan = true )
+        : Viewport( width, height, 1, 2, allowZoom, allowPan )
+    { }
+
+    void setData( std::function<std::optional<double>( double, double )> sampler, double minValue, double maxValue )
+    {
+        M_sampler = sampler;
+        M_minValue = minValue;
+        M_maxValue = maxValue;
+    }
+
+    ftxui::Element OnRender() override;
+
+
+private:
+    double M_minValue = 0.0;
+    double M_maxValue = 1.0;
+    std::function<std::optional<double>( double, double )> M_sampler;
+};
+
+
+
+
+}

--- a/src/feel/feelcore/tui/logviewer.cpp
+++ b/src/feel/feelcore/tui/logviewer.cpp
@@ -1,0 +1,92 @@
+//!
+
+
+#include "feel/feelcore/tui/decorators.hpp"
+#include <feel/feelcore/tui/logviewer.hpp>
+
+
+namespace Feel::Core::tui
+{
+
+
+template<typename MutexType>
+void
+TuiLogSink<MutexType>::sink_it_( log::details::log_msg const& msg )
+{
+    log::memory_buf_t formatted;
+    this->formatter_->format( msg, formatted );
+    std::string logMsg = fmt::to_string( formatted );
+
+    // Strip trailing newline if present
+    if ( !logMsg.empty() && logMsg.back() == '\n' )
+        logMsg.pop_back();
+
+    std::lock_guard<std::mutex> lock( M_storage->mutex );
+    M_storage->entries.push_back( TuiLogEntry{ logMsg, msg.level, std::chrono::system_clock::now() } );
+
+    // Limit the queue
+    if ( M_storage->entries.size() > M_storage->maxEntries )
+        M_storage->entries.pop_front();
+}
+
+
+TuiLogViewerComponent::TuiLogViewerComponent( std::size_t maxEntries )
+    : ScrollableList( " Logs ", true )
+{
+    M_storage = std::make_shared<TuiLogStorage>();
+    M_storage->maxEntries = maxEntries;
+    auto sink = std::make_shared<TuiLogSink<std::mutex>>( M_storage );
+    log::default_logger()->sinks().push_back( sink );
+
+    ScrollableList::Add(
+        ftxui::Container::Horizontal( { M_debugCheckbox, M_infoCheckbox , M_warnCheckbox, M_errorCheckbox } )
+    );
+}
+
+
+
+
+std::optional<ftxui::Element>
+TuiLogViewerComponent::buildHeader()
+{
+    return ftxui::hbox({
+        ftxui::text("Filters:  ") | ftxui::dim,
+        M_debugCheckbox->Render() | ftxui::color( ftxui::Color::GrayDark ),
+        ftxui::text("   "),
+        M_infoCheckbox->Render() | ftxui::color( ftxui::Color::GreenLight ),
+        ftxui::text("   "),
+        M_warnCheckbox->Render() | ftxui::color( ftxui::Color::Yellow ),
+        ftxui::text("   "),
+        M_errorCheckbox->Render() | ftxui::color( ftxui::Color::RedLight )
+    });
+}
+
+
+std::vector<ftxui::Element>
+TuiLogViewerComponent::buildElements()
+{
+    std::lock_guard<std::mutex> lock( M_storage->mutex );
+    std::vector<ftxui::Element> logElements;
+    for ( const auto& entry : M_storage->entries )
+    {
+        if ( entry.level == log::level::trace && !M_showDebug ) continue;
+        if ( entry.level == log::level::debug && !M_showDebug ) continue;
+        if ( entry.level == log::level::info  && !M_showInfo )  continue;
+        if ( entry.level == log::level::warn  && !M_showWarn )  continue;
+        if ( (entry.level == log::level::err || entry.level == log::level::critical) && !M_showError ) continue;
+
+
+        ftxui::Color color = ftxui::Color::White;
+        if ( M_levelColorMap.contains( entry.level ) )
+            color = M_levelColorMap.at( entry.level );
+
+        logElements.push_back( ftxui::paragraph( entry.message ) | ftxui::color( color ) );
+    }
+    return logElements;
+}
+
+
+
+}
+
+

--- a/src/feel/feelcore/tui/logviewer.cpp
+++ b/src/feel/feelcore/tui/logviewer.cpp
@@ -36,7 +36,7 @@ TuiLogViewerComponent::TuiLogViewerComponent( std::size_t maxEntries )
     M_storage = std::make_shared<TuiLogStorage>();
     M_storage->maxEntries = maxEntries;
     auto sink = std::make_shared<TuiLogSink<std::mutex>>( M_storage );
-    log::default_logger()->sinks().push_back( sink );
+    log::set_default_logger( std::make_shared<log::logger>( "TuiLogViewer", sink ) );
 
     ScrollableList::Add(
         ftxui::Container::Horizontal( { M_debugCheckbox, M_infoCheckbox , M_warnCheckbox, M_errorCheckbox } )

--- a/src/feel/feelcore/tui/logviewer.hpp
+++ b/src/feel/feelcore/tui/logviewer.hpp
@@ -1,0 +1,100 @@
+//!
+
+#pragma once
+
+#include <deque>
+
+#include <spdlog/sinks/base_sink.h>
+
+#include <feel/feelcore/tui/decorators.hpp>
+
+namespace Feel::Core::tui
+{
+
+//! A single log entry for the TUI log viewer.
+struct TuiLogEntry
+{
+    std::string message;
+    log::level::level_enum level;
+    std::chrono::system_clock::time_point timestamp;
+};
+
+//! Storage for log entries, with a maximum number of entries to keep.
+struct TuiLogStorage {
+    std::mutex mutex;
+    std::deque<TuiLogEntry> entries;
+    std::size_t maxEntries = 100;
+};
+
+//! A custom spdlog sink that stores log entries in a TuiLogStorage for display in a TUI log viewer.
+template<typename MutexType>
+class TuiLogSink
+    : public log::sinks::base_sink<MutexType>
+{
+public:
+    explicit TuiLogSink( std::shared_ptr<TuiLogStorage> storage ) : M_storage( storage ) {}
+
+protected:
+
+    //! Called by spdlog when a log message is emitted. Stores the log message in the TuiLogStorage.
+    void sink_it_( log::details::log_msg const& msg ) override;
+
+    void flush_() override {}
+
+private:
+    std::shared_ptr<TuiLogStorage> M_storage;
+};
+
+
+//! A TUI component that displays log entries in a scrollable list, with optional filters for log levels.
+class TuiLogViewerComponent
+    : public ScrollableList
+{
+public:
+    //! @param maxEntries The maximum number of log entries to keep in the viewer.
+    explicit TuiLogViewerComponent( std::size_t maxEntries = 100 );
+
+    //! Clear all log entries from the viewer.
+    void clear()
+    {
+        std::lock_guard<std::mutex> lock( M_storage->mutex );
+        M_storage->entries.clear();
+    }
+
+private:
+    //! Build the header element with log level filters.
+    std::optional<ftxui::Element> buildHeader() override;
+
+    //! Build the logs paragraph elements to be displayed in the scrollable list, applying log level filters.
+    std::vector<ftxui::Element> buildElements() override;
+
+private:
+    std::shared_ptr<TuiLogStorage> M_storage;
+
+    //Filters
+    bool M_showDebug = true;
+    ftxui::Component M_debugCheckbox = ftxui::Checkbox( "Debug", &M_showDebug );
+
+    bool M_showInfo  = true;
+    ftxui::Component M_infoCheckbox = ftxui::Checkbox( "Info", &M_showInfo );
+
+    bool M_showWarn  = true;
+    ftxui::Component M_warnCheckbox = ftxui::Checkbox( "Warn", &M_showWarn );
+
+    bool M_showError = true;
+    ftxui::Component M_errorCheckbox = ftxui::Checkbox( "Error", &M_showError );
+
+    std::map<log::level::level_enum, ftxui::Color> M_levelColorMap = {
+        { log::level::debug, ftxui::Color::GrayDark },
+        { log::level::trace, ftxui::Color::GrayLight },
+        { log::level::info, ftxui::Color::GreenLight },
+        { log::level::warn, ftxui::Color::Yellow },
+        { log::level::critical, ftxui::Color::Red },
+        { log::level::err, ftxui::Color::RedLight }
+    };
+
+};
+
+}
+
+

--- a/src/feel/feelcore/tui/timekeeperviewer.cpp
+++ b/src/feel/feelcore/tui/timekeeperviewer.cpp
@@ -1,0 +1,147 @@
+//!
+
+#include <ftxui/component/event.hpp>
+
+#include <feel/feelcore/tui/timekeeperviewer.hpp>
+
+
+namespace Feel::Core::tui
+{
+
+
+std::vector<ftxui::Element>
+TuiTimekeeperViewerComponent::buildElements()
+{
+    nl::json timesSnapshot = Timekeeper::instance()->getTimesSnapshot();
+
+    std::vector<ftxui::Element> lines;
+    M_nodeBoxes.clear();
+
+    auto now = std::chrono::system_clock::now().time_since_epoch();
+    int ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+
+    std::function<void( std::string const &, nl::json const&, int, std::string const&)> renderNode;
+    renderNode = [&]( std::string const& name, nl::json const& node, int currentDepth, std::string const& currentPath)
+    {
+        if ( currentDepth > M_maxDepth ) return;
+
+        bool hasChildren = node.contains( "subsections" ) && !node["subsections"].empty();
+        bool isCollapsed = M_collapsedNodes.contains( currentPath );
+
+        std::string timeStr = "0.00s";
+        std::string detailStr = "";
+        ftxui::Color timeColor;
+        bool isMultiThreaded = false;
+        if ( node.contains( "times" ) )
+        {
+            auto const& times = node[ "times" ];
+            isMultiThreaded = times.contains( "max" ) && times.contains( "elapsed_sum" ) && times.value( "count", 1 ) > 1;
+            if ( isMultiThreaded )
+            {
+                double sum_time = times[ "elapsed_sum" ].get<double>();
+                double max_time = times[ "max" ].get<double>();
+                int count = times.value( "count", 1 );
+
+                timeStr = fmt::format( "{:.2f}s", max_time );
+                detailStr = fmt::format( "sum: {:.2f}s ({}x)", sum_time, count );
+            }
+            else if ( times.contains( "elapsed" ) )
+                timeStr = fmt::format( "{:.2f}s", times["elapsed"].get<double>() );
+            else
+                timeStr = "0.00s";
+
+            timeColor = ftxui::Color::Cyan;
+        }
+        else
+        {
+            std::vector<std::string> spinner = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
+            timeStr = spinner[(ms / 100) % spinner.size()];
+            timeColor = ftxui::Color::Yellow;
+        }
+
+        std::string indent( currentDepth * 2, ' ' );
+        std::string prefix = ( currentDepth == 0 ) ? "" : "├─ ";
+
+        std::string collapseIcon = hasChildren ? ( isCollapsed ? "▶ " : "▼ " ) : "  ";
+
+        ftxui::Color branchColor = isMultiThreaded ? ftxui::Color::Magenta : ftxui::Color::GrayLight;
+
+        ftxui::Elements block;
+
+        block.push_back(
+            ftxui::hbox({
+                ftxui::text( indent + prefix + collapseIcon ) |  ftxui::color( branchColor ),
+                ftxui::text( name ),
+                ftxui::filler(),
+                ftxui::text( timeStr ) | ftxui::bold | ftxui::color( timeColor )
+            })
+        );
+
+        if ( !detailStr.empty() )
+        {
+            std::string detailIndent( ( currentDepth * 2 ) + 2 + (hasChildren ? 2 : 0), ' ' );
+            block.push_back(
+                ftxui::hbox({
+                    ftxui::text( detailIndent + "└ " ) | ftxui::color( branchColor ),
+                    ftxui::text( detailStr ) | ftxui::dim | ftxui::color( ftxui::Color::GrayLight ),
+                    ftxui::filler()
+                })
+            );
+        }
+
+        M_nodeBoxes.push_back( { currentPath, ftxui::Box{}, hasChildren } );
+        lines.push_back( ftxui::vbox( block ) | ftxui::reflect( M_nodeBoxes.back().box ) );
+
+        if ( currentDepth < M_maxDepth && hasChildren && !isCollapsed )
+            for ( auto it = node[ "subsections" ].begin(); it != node[ "subsections" ].end(); ++it )
+                renderNode( it.key(), it.value(), currentDepth + 1, currentPath + "." + it.key());
+    };
+
+    for ( auto it = timesSnapshot.begin(); it != timesSnapshot.end(); ++it )
+        renderNode( it.key(), it.value(), 0, it.key() );
+
+    return lines;
+}
+
+
+
+std::optional<ftxui::Element>
+TuiTimekeeperViewerComponent::buildFooter()
+{
+    return ftxui::hbox({
+        ftxui::text( "Legend: " ) | ftxui::dim,
+        ftxui::filler(),
+        ftxui::text( "■ " ) | ftxui::color( ftxui::Color::Magenta ),
+        ftxui::text( "Multi " ),
+        ftxui::filler(),
+        ftxui::text( "⠋ " ) | ftxui::color( ftxui::Color::Yellow ),
+        ftxui::text( "Running " ),
+        ftxui::filler(),
+        ftxui::text( "Done" ) | ftxui::color( ftxui::Color::Cyan ) | ftxui::bold
+    }) | ftxui::center;
+}
+
+bool
+TuiTimekeeperViewerComponent::OnEvent( ftxui::Event event )
+{
+    if ( event.is_mouse() && event.mouse().button == ftxui::Mouse::Left && event.mouse().motion == ftxui::Mouse::Pressed )
+    {
+        for ( auto & node : M_nodeBoxes )
+        {
+            if ( node.hasChildren && node.box.Contain( event.mouse().x, event.mouse().y ) )
+            {
+                if ( M_collapsedNodes.contains( node.path ) )
+                    M_collapsedNodes.erase( node.path );
+                else
+                    M_collapsedNodes.insert( node.path );
+
+                return true;
+            }
+        }
+    }
+
+    return ScrollableList::OnEvent( event );
+}
+
+
+}

--- a/src/feel/feelcore/tui/timekeeperviewer.hpp
+++ b/src/feel/feelcore/tui/timekeeperviewer.hpp
@@ -1,0 +1,53 @@
+
+//!
+
+#pragma once
+
+#include <list>
+#include <set>
+
+#include <feel/feelcore/timekeeper.hpp>
+#include <feel/feelcore/tui/decorators.hpp>
+
+namespace Feel::Core::tui
+{
+
+//! A TUI component that displays the recorded times from the Timekeeper in a scrollable and collapsible list.
+class TuiTimekeeperViewerComponent
+    : public ScrollableList
+{
+public:
+
+    //! @param maxDepth The maximum depth of the timekeeping hierarchy to display.
+    explicit TuiTimekeeperViewerComponent( int maxDepth = 3 )
+        : ScrollableList( " Timekeeper " ), M_maxDepth( maxDepth )
+    {}
+
+
+    //! Clear all recorded times from the Timekeeper.
+    void clear() { Timekeeper::instance()->clear(); }
+
+    //! Builds the timer hierarchy elements to be displayed in the scrollable list.
+    std::vector<ftxui::Element> buildElements() override;
+
+    //! Builds the legend footer element to be displayed below the list.
+    std::optional<ftxui::Element> buildFooter() override;
+
+    //! Handles mouse events for collapsing and expanding nodes in the timer hierarchy.
+    bool OnEvent( ftxui::Event event ) override;
+
+private:
+    int M_maxDepth;
+
+    struct NodeBox
+    {
+        std::string path;
+        ftxui::Box box;
+        bool hasChildren;
+    };
+
+    std::list<NodeBox> M_nodeBoxes;
+    std::set<std::string> M_collapsedNodes;
+};
+
+}

--- a/src/feel/feelcore/tui/viewport.cpp
+++ b/src/feel/feelcore/tui/viewport.cpp
@@ -1,0 +1,125 @@
+//!
+
+#include <feel/feelcore/tui/viewport.hpp>
+
+
+
+namespace Feel::Core::tui
+{
+
+
+
+bool
+Viewport::OnEvent( ftxui::Event event )
+{
+    if ( !event.is_mouse() )
+        return false;
+
+    auto mouse = event.mouse();
+    if ( !isInsideBox( mouse.x, mouse.y ) )
+        return false;
+
+
+    if ( M_allowZoom )
+    {
+        double scale = 1.0;
+
+        if ( mouse.button == ftxui::Mouse::WheelUp )
+            scale = 1.15;
+        if ( mouse.button == ftxui::Mouse::WheelDown )
+            scale = 1.0 / 1.15;
+
+        if ( scale != 1.0 )
+        {
+            double sx = ( mouse.x - M_box.x_min ) * M_scaleX;
+            double sy = ( mouse.y - M_box.y_min ) * M_scaleY;
+
+            double mathSy = M_flipY ? (M_height - sy - 1.0) : sy;
+
+            M_pan.x() = sx - ( sx - M_pan.x() ) * scale;
+            M_pan.y() = mathSy - ( mathSy - M_pan.y() ) * scale;
+
+            M_zoom *= scale;
+            return true;
+        }
+    }
+
+    if ( M_allowPan )
+    {
+        if ( mouse.button == ftxui::Mouse::Right )
+        {
+            if ( mouse.motion == ftxui::Mouse::Pressed )
+            {
+                M_isDragging = true;
+                M_lastMousePos = { mouse.x, mouse.y };
+                return true;
+            }
+            else if ( mouse.motion == ftxui::Mouse::Moved && M_isDragging )
+            {
+                int deltaX = ( mouse.x - M_lastMousePos.x() ) * M_scaleX;
+                int deltaY = ( mouse.y - M_lastMousePos.y() ) * M_scaleY;
+                M_pan.x() += deltaX;
+                M_pan.y() += M_flipY ? -deltaY : deltaY;
+
+                M_lastMousePos = { mouse.x, mouse.y };
+                return true;
+            }
+            else if ( mouse.motion == ftxui::Mouse::Released )
+            {
+                M_isDragging = false;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void
+Viewport::fitToBoundingBox( double minX, double minY, double maxX, double maxY, bool flipY )
+{
+    M_flipY = flipY;
+
+    double rangeX = std::max( maxX - minX, 1.0 );
+    double rangeY = std::max( maxY - minY, 1.0 );
+
+    M_zoom = std::min( M_width / rangeX, M_height / rangeY ) * 0.90;
+
+    M_pan.x() = ( M_width - ( rangeX * M_zoom) ) / 2.0 - ( minX * M_zoom );
+    M_pan.y() = ( M_height - ( rangeY * M_zoom) ) / 2.0 - ( minY * M_zoom );
+}
+
+
+
+std::pair<double, double>
+Viewport::worldToScreen( double worldX, double worldY ) const
+{
+    double screenX = worldX * M_zoom + M_pan.x();
+    double screenY = worldY * M_zoom + M_pan.y();
+
+    if (M_flipY)
+        screenY = M_height - screenY - 1.0;
+
+    return { screenX, screenY };
+}
+
+
+
+std::pair<double,double>
+Viewport::screenToWorld( int x, int y ) const
+{
+    int xBox = ( x - M_box.x_min ) * M_scaleX;
+    int yBox = ( y - M_box.y_min ) * M_scaleY;
+
+    if ( M_flipY )
+        yBox = M_height - yBox - 1;
+
+    double worldX = ( xBox - M_pan.x() ) / M_zoom;
+    double worldY = ( yBox - M_pan.y() ) / M_zoom;
+
+    return { worldX, worldY };
+}
+
+
+}
+

--- a/src/feel/feelcore/tui/viewport.hpp
+++ b/src/feel/feelcore/tui/viewport.hpp
@@ -1,0 +1,89 @@
+//!
+
+#pragma once
+
+#include <ftxui/component/component_base.hpp>
+#include <feel/feelcore/feelcore.hpp>
+
+#include <ftxui/component/event.hpp>
+
+
+namespace Feel::Core::tui
+{
+
+
+//! A viewport base class that allows zooming and panning of a 2D space.
+//! Designed to serve as a base class for canvas-like components or nodes that require camera-like functionality.
+class Viewport
+    : public ftxui::ComponentBase
+{
+public:
+    Viewport( int width = 80, int height = 80,
+              int scaleX = 2, int scaleY = 4,
+              bool allowZoom = false, bool allowPan = false )
+    : M_width( width ), M_height( height ),
+      M_scaleX( scaleX ), M_scaleY( scaleY ),
+      M_allowZoom( allowZoom ), M_allowPan( allowPan )
+    {}
+
+
+    //! Handle mouse events for zooming and panning the viewport.
+    bool OnEvent( ftxui::Event event ) override;
+
+    //! Reset the viewport to its default zoom and pan settings.
+    void resetView()
+    {
+        M_zoom = 1.0;
+        M_pan = { 0,0 };
+        M_isDragging = false;
+    }
+
+    //! Get the UI box representing the viewport area on the screen.
+    ftxui::Box const& box() const noexcept { return M_box; }
+
+    //! Check if a given screen coordinate is inside the viewport box.
+    bool isInsideBox( int x, int y ) const { return M_box.Contain( x,y ); }
+
+    //! Fit the viewport to a specified bounding box in world coordinates, optionally flipping the Y-axis.
+    void fitToBoundingBox( double minX, double minY, double maxX, double maxY, bool flipY = true );
+
+    //! Convert world coordinates to screen coordinates based on the current zoom and pan settings.
+    std::pair<double, double> worldToScreen( double worldX, double worldY ) const;
+
+    //! Convert screen coordinates to world coordinates based on the current zoom and pan settings.
+    std::pair<double,double> screenToWorld( int x, int y ) const;
+
+protected:
+    template <typename T, std::size_t N>
+    struct Point
+    {
+        T& operator[]( std::size_t index ) { return data[index]; }
+        T const& operator[]( std::size_t index ) const { return data[index]; }
+
+        T& x() { return data[0]; }
+        T const& x() const { return data[0]; }
+
+        T& y() { return data[1]; }
+        T const& y() const { return data[1]; }
+
+        std::array<T,N> data;
+    };
+
+
+    ftxui::Box M_box;
+
+    int M_width, M_height;
+
+    int M_scaleX, M_scaleY;
+
+    bool M_allowZoom, M_allowPan;
+    double M_zoom = 1.0;
+    Point<double,2> M_pan = { 0., 0. };
+    bool M_isDragging = false;
+    Point<int,2> M_lastMousePos = { 0,0 };
+
+    bool M_flipY = false;
+};
+
+
+}


### PR DESCRIPTION
Add multiple generic components for the TUI

- [x] Add generic "decorators" : `ScrollableList` and `SearchableList` allowing to have a mouse-scrollable window and a search bar with bulk actions.
<img width="187" height="130" alt="Screenshot 2026-07-06 at 15 23 47" src="https://github.com/user-attachments/assets/a6d8fe1e-d226-4b0b-9908-5a60eacb4a5c" />

- [x] Add a `LogViewer` : A scrollable and filterable window showing all logs from spdlog
<img width="684" height="154" alt="Screenshot 2026-07-06 at 15 24 33" src="https://github.com/user-attachments/assets/4cee6d87-ca7e-48d4-a21b-f869cd952ee2" />

- [x] Add thread safe `Timekeeper` singleton and a RAII `Timer` that records times as json.
- [x] Add a `TimekeeperViewer` TUI component allowing to view live timers from timekeeper as collapsible elements.
<img width="315" height="253" alt="Screenshot 2026-07-06 at 15 27 12" src="https://github.com/user-attachments/assets/63e32591-f3a0-419d-b6eb-e017a8fdaba6" />

- [x] Add a `Viewport` component serving as a base class for zoomable and pannable canvas/nodes or other components. Handles camera-like behaviour
- [x] Add a `Heatmap` component that renders a function into a heatmap (handles downsizing when scrolling)

<img width="414" height="436" alt="Screenshot 2026-07-06 at 15 58 32" src="https://github.com/user-attachments/assets/66cb8655-80af-44da-8484-cf719fac07fd" />


- Usage is pretty straightforward : 

```c++
    auto logViewer = TuiLogViewer( 100 ); // 100 is max logs to show
    auto timekeeperViewer = TuiTimekeeperViewer( 3 ); // 3 is max tree depth
    
    //Heatmap
    auto heatmap = Heatmap( 40, 20 );
    heatmap->setData( []( double x, double y ) -> std::optional<double> {
        if ( x < -100 || x > 100 || y < -100 || y > 100 )
            return std::nullopt;

        double value = std::sin( x * 10 ) * std::cos( y * 10 );
        return value;
    }, -1.0, 1.0 );

```